### PR TITLE
Adding correction for multiple comparisons to politenessPlot

### DIFF
--- a/R/politenessPlot.R
+++ b/R/politenessPlot.R
@@ -106,7 +106,10 @@ politenessPlot<-function(df_polite,
   if(middle_out<1){
     split.p<-unlist(lapply(names(df_polite), function(x) stats::t.test(l_polite_split[[1]][,x],
                                                                        l_polite_split[[2]][,x])$p.value))
-    split.enough<-names(df_polite)[(split.p<middle_out)&(!is.na(split.p))]
+    # For hypothesis-driven tests (e.g. to check p < 0.05) 
+    # it would make sense to correct for multiple comparisons before outputting
+    corrected_ps <- p.adjust(split.p, method="holm")
+    split.enough<-names(df_polite)[(corrected_ps<middle_out)&(!is.na(split.p))]
   }
 
   if(sum((split.data$feature%in%nonblanks)&(split.data$feature%in%split.enough))==0){


### PR DESCRIPTION
I am using this for a hypothesis driven research question, and I noticed there doesn't seem to be an adjustment for multiple comparisons here. I introduced a check using Holm's sequential Bonferroni procdure. See:
 https://pdfs.semanticscholar.org/7210/4483da360a994a165d252a6cc935ce594f55.pdf
https://www.rdocumentation.org/packages/stats/versions/3.6.2/topics/p.adjust

 I think it would be great to add here, or add as an optional parameter to politenessPlot.